### PR TITLE
Fix build on bionic

### DIFF
--- a/include/ignition/async_web_server_cpp/http_connection.hh
+++ b/include/ignition/async_web_server_cpp/http_connection.hh
@@ -3,7 +3,13 @@
 
 #include <asio/io_service.hpp>
 #include <asio/ip/tcp.hpp>
-#include <asio/strand.hpp>
+#include <asio/version.hpp>
+
+#if ASIO_VERSION < 101200
+  #include <asio/strand.hpp>
+#else
+  #include <asio/io_context_strand.hpp>
+#endif
 
 #include "ignition/async_web_server_cpp/http_fwd.hh"
 #include "ignition/async_web_server_cpp/http_request_handler.hh"

--- a/include/ignition/async_web_server_cpp/http_connection.hh
+++ b/include/ignition/async_web_server_cpp/http_connection.hh
@@ -2,8 +2,8 @@
 #define IGNITION__ASYNC_WEB_SERVER_CPP__HTTP_CONNECTION_HH_
 
 #include <asio/io_service.hpp>
-#include <asio/io_context_strand.hpp>
 #include <asio/ip/tcp.hpp>
+#include <asio/strand.hpp>
 
 #include "ignition/async_web_server_cpp/http_fwd.hh"
 #include "ignition/async_web_server_cpp/http_request_handler.hh"

--- a/src/web_video_server/CMakeLists.txt
+++ b/src/web_video_server/CMakeLists.txt
@@ -20,6 +20,7 @@ target_link_libraries(
   ignition-common3::ignition-common3
   ignition-common3::graphics
   ignition-common3::av
+  stdc++fs
 )
 
 add_executable(

--- a/src/web_video_server/libav_streamer.cc
+++ b/src/web_video_server/libav_streamer.cc
@@ -77,7 +77,7 @@ LibavStreamer::LibavStreamer(const async_web_server_cpp::HttpRequest &_request,
   gop = get_int("gop", 25);
 
 #if ( LIBAVCODEC_VERSION_INT  < AV_VERSION_INT(58,9,100) )
-  av_lockmgr_register(&ffmpeg_boost_mutex_lock_manager);
+  av_lockmgr_register(&ffmpeg_mutex_lock_manager);
   av_register_all();
 #endif
 }


### PR DESCRIPTION
* Added asio version check for including headers. Looks like `io_context_strand.hpp` is available on [asio 1.12.0](https://github.com/chriskohlhoff/asio/tree/asio-1-12-0/asio/include/asio) and above. Ubuntu Bionic comes with asio 1.10.8
* I'm on gcc /++8.4.0 and I had to link explicitly link against stdc++fs


Signed-off-by: Ian Chen <ichen@osrfoundation.org>